### PR TITLE
gitignore: Ignore all .egg-info directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist
 build
-microscope.egg-info
+*.egg-info
 
 cilium-*
 pyz


### PR DESCRIPTION
After building the current master branch of microscope, the name
of egg directory is cilium_microscope.egg-info instead of
microscope.egg-info. To ensure that no .egg-info directories will
be able to be commited, let's ignore all of them.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>